### PR TITLE
Drbloom patch2

### DIFF
--- a/_posts/2015-12-07-Synereo-Update-02.12-Scribed.markdown
+++ b/_posts/2015-12-07-Synereo-Update-02.12-Scribed.markdown
@@ -3,7 +3,7 @@ layout: post
 status: publish
 published: true
 title: Scribe Notes For Synereo Weekly Update
-date: '2015-12-02 08:00:00 +0200'
+date: '2015-12-07 08:00:00 +0200'
 ---
 
 ## Scribe Role Update

--- a/_posts/2015-12-13-Synereo-Update-09.12-Scribed.markdown
+++ b/_posts/2015-12-13-Synereo-Update-09.12-Scribed.markdown
@@ -3,7 +3,7 @@ layout: post
 status: publish
 published: true
 title: Scribe Notes For Synereo Weekly Update
-date: '2015-12-09 08:00:00 +0200'
+date: '2015-12-13 08:00:00 +0200'
 ---
 
 ## Development Update

--- a/_posts/2015-12-21-Synereo-Update-16.12-Scribed.markdown
+++ b/_posts/2015-12-21-Synereo-Update-16.12-Scribed.markdown
@@ -3,7 +3,7 @@ layout: post
 status: publish
 published: true
 title: Scribe Notes For Synereo Weekly Update
-date: '2015-12-16 08:00:00 +0200'
+date: '2015-12-21 08:00:00 +0200'
 ---
 
 ## Update Summary

--- a/_posts/2015-12-23-Synereo-Update.markdown
+++ b/_posts/2015-12-23-Synereo-Update.markdown
@@ -3,7 +3,7 @@ layout: post
 status: publish
 published: true
 title: Scribe Notes For Synereo Weekly Update
-date: '2015-12-23 08:00:00 +0200'
+date: '2016-01-04 08:00:00 +0200'
 ---
 
 ## Update Summary

--- a/_posts/2016-01-07-Synereo-Update.markdown
+++ b/_posts/2016-01-07-Synereo-Update.markdown
@@ -3,7 +3,7 @@ layout: post
 status: publish
 published: true
 title: Synereo Weekly Update
-date: '2016-01-06 08:00:00 +0200'
+date: '2016-01-12 08:00:00 +0200'
 ---
 
 ## Update Summary

--- a/_posts/2016-01-14-Synereo-Update.markdown
+++ b/_posts/2016-01-14-Synereo-Update.markdown
@@ -3,7 +3,7 @@ layout: post
 status: publish
 published: true
 title: Synereo Weekly Update
-date: '2016-01-13 08:00:00 +0200'
+date: '2016-01-20 08:00:00 +0200'
 ---
 
 ## Update Summary

--- a/_posts/2016-01-20-Synereo-Update.markdown
+++ b/_posts/2016-01-20-Synereo-Update.markdown
@@ -3,7 +3,7 @@ layout: post
 status: publish
 published: true
 title: Synereo Weekly Update
-date: '2016-01-20 08:00:00 +0200'
+date: '2016-02-02 08:00:00 +0200'
 ---
 
 ## Update Summary

--- a/_posts/2016-01-27-Synereo-Update.markdown
+++ b/_posts/2016-01-27-Synereo-Update.markdown
@@ -3,7 +3,7 @@ layout: post
 status: publish
 published: true
 title: Synereo Weekly Update
-date: '2016-01-27 08:00:00 +0200'
+date: '2016-02-07 08:00:00 +0200'
 ---
 
 ## Update Summary


### PR DESCRIPTION
My previous patch had set the date displayed in 8 blog entries to reflect the date of the actual hangout. This changed the url for each blog entry, breaking any external link pointing to the blog entry. This patch sets the dates back to what they were.
